### PR TITLE
Added ability to specifiy filter worker threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,16 @@ a suite file defines a series of tests to run.
 #### suite file format
 
 ```ruby
+# format description:
 # each test can be executed by either target duration using :time => N secs
 # or by number of events with :events => N
 #
+# you can specify the number of filter worker threads for each test with :workers => N
+# if you don't specify workers, it defaults to 1
+#
 #[
 #  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 30},
-#  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
+#  {:workers => 2, :name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
 #]
 #
 [
@@ -88,7 +92,7 @@ a suite file defines a series of tests to run.
   {:name => "simple line out", :config => "config/simple.conf", :input => "input/simple_10.txt", :time => 60},
   {:name => "json codec", :config => "config/json_inout_codec.conf", :input => "input/json_medium.txt", :time => 60},
   {:name => "json filter", :config => "config/json_inout_filter.conf", :input => "input/json_medium.txt", :time => 60},
-  {:name => "complex syslog", :config => "config/complex_syslog.conf", :input => "input/syslog_acl_10.txt", :time => 60},
+  {:workers => 2, :name => "complex syslog", :config => "config/complex_syslog.conf", :input => "input/syslog_acl_10.txt", :time => 60},
 ]
 ```
 

--- a/examples/suite/basic_performance_long.rb
+++ b/examples/suite/basic_performance_long.rb
@@ -2,9 +2,12 @@
 # each test can be executed by either target duration using :time => N secs
 # or by number of events with :events => N
 #
+# you can specify the number of filter worker threads for each test with :workers => N
+# if you don't specify workers, it defaults to 1
+#
 #[
 #  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 30},
-#  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
+#  {:workers => 2, :name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
 #]
 #
 [

--- a/examples/suite/basic_performance_long_with_workers.rb
+++ b/examples/suite/basic_performance_long_with_workers.rb
@@ -1,0 +1,21 @@
+# format description:
+# each test can be executed by either target duration using :time => N secs
+# or by number of events with :events => N
+#
+# you can specify the number of filter worker threads for each test with :workers => N
+# if you don't specify workers, it defaults to 1
+#
+#[
+#  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 30},
+#  {:workers => 2, :name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
+#]
+#
+[
+  {:workers => 2, :name => "simple line in/out", :config => "config/simple.conf", :input => "input/simple_10.txt", :time => 120},
+  {:workers => 2, :name => "simple line in/json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 120},
+  {:workers => 2, :name => "json codec in/out", :config => "config/json_inout_codec.conf", :input => "input/json_medium.txt", :time => 120},
+  {:workers => 2, :name => "line in/json filter/json out", :config => "config/json_inout_filter.conf", :input => "input/json_medium.txt", :time => 120},
+  {:workers => 2, :name => "apache in/json out", :config => "config/simple.conf", :input => "input/apache_log.txt", :time => 120},
+  {:workers => 2, :name => "apache in/grok codec/json out", :config => "config/simple_grok.conf", :input => "input/apache_log.txt", :time => 120},
+  {:workers => 2, :name => "syslog in/json out", :config => "config/complex_syslog.conf", :input => "input/syslog_acl_10.txt", :time => 120},
+]

--- a/examples/suite/basic_performance_quick.rb
+++ b/examples/suite/basic_performance_quick.rb
@@ -2,9 +2,12 @@
 # each test can be executed by either target duration using :time => N secs
 # or by number of events with :events => N
 #
+# you can specify the number of filter worker threads for each test with :workers => N
+# if you don't specify workers, it defaults to 1
+#
 #[
 #  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 30},
-#  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
+#  {:workers => 2, :name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
 #]
 #
 [

--- a/examples/suite/basic_performance_quick_with_workers.rb
+++ b/examples/suite/basic_performance_quick_with_workers.rb
@@ -1,0 +1,21 @@
+# format description:
+# each test can be executed by either target duration using :time => N secs
+# or by number of events with :events => N
+#
+# you can specify the number of filter worker threads for each test with :workers => N
+# if you don't specify workers, it defaults to 1
+#
+#[
+#  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 30},
+#  {:workers => 2, :name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
+#]
+#
+[
+  {:workers => 2, :name => "simple line in/out", :config => "config/simple.conf", :input => "input/simple_10.txt", :time => 30},
+  {:workers => 2, :name => "simple line in/json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 30},
+  {:workers => 2, :name => "json codec in/out", :config => "config/json_inout_codec.conf", :input => "input/json_medium.txt", :time => 30},
+  {:workers => 2, :name => "line in/json filter/json out", :config => "config/json_inout_filter.conf", :input => "input/json_medium.txt", :time => 30},
+  {:workers => 2, :name => "apache in/json out", :config => "config/simple.conf", :input => "input/apache_log.txt", :time => 30},
+  {:workers => 2, :name => "apache in/grok codec/json out", :config => "config/simple_grok.conf", :input => "input/apache_log.txt", :time => 30},
+  {:workers => 2, :name => "syslog in/json out", :config => "config/complex_syslog.conf", :input => "input/syslog_acl_10.txt", :time => 30},
+]

--- a/lib/lsperfm/core.rb
+++ b/lib/lsperfm/core.rb
@@ -23,8 +23,9 @@ module LogStash::PerformanceMeter
       tests.each do |test|
         events  = test[:events].to_i
         time    = test[:time].to_i
+        workers = test[:workers] ? test[:workers].to_s : "1"
 
-        manager = runner.new(find_test_config(test[:config]), debug, install_path)
+        manager = runner.new(find_test_config(test[:config]), workers, debug, install_path)
         metrics = manager.run(events, time, runner.read_input_file(find_test_input(test[:input])))
         lines << formatter(test[:name], metrics)
       end

--- a/lib/lsperfm/core/run.rb
+++ b/lib/lsperfm/core/run.rb
@@ -18,9 +18,9 @@ module LogStash::PerformanceMeter
 
     attr_reader :command
 
-    def initialize(config, debug = false, logstash_home = Dir.pwd)
+    def initialize(config, workers = "1", debug = false, logstash_home = Dir.pwd)
       @debug = debug
-      @command = [File.join(logstash_home, LOGSTASH_BIN), "-f", config]
+      @command = [File.join(logstash_home, LOGSTASH_BIN), "-f", config, "-w", workers]
     end
 
     def run(required_events_count, required_run_time, input_lines)

--- a/spec/fixtures/worker_basic_suite.rb
+++ b/spec/fixtures/worker_basic_suite.rb
@@ -1,0 +1,4 @@
+[
+  {:workers => 2, :name => "simple 1", :config => "simple.conf", :input => "simple_10.txt", :time => 5},
+  {:workers => "2", :name => "simple 2", :config => "simple.conf", :input => "simple_10.txt", :time => 10},
+]

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -10,7 +10,7 @@ describe LogStash::PerformanceMeter::Runner do
 
   subject (:runner) { LogStash::PerformanceMeter::Runner.new(config) }
 
-  let(:command) { [File.join(Dir.pwd, LogStash::PerformanceMeter::Runner::LOGSTASH_BIN), "-f", "spec/fixtures/simple.conf"]}
+  let(:command) { [File.join(Dir.pwd, LogStash::PerformanceMeter::Runner::LOGSTASH_BIN), "-f", "spec/fixtures/simple.conf", "-w", "1"]}
 
   it "invokes the logstash command" do
     Open3.should_receive(:popen3).with(*command).and_return(true)

--- a/spec/lib/worker_suite_spec.rb
+++ b/spec/lib/worker_suite_spec.rb
@@ -4,14 +4,14 @@ describe LogStash::PerformanceMeter::Core do
 
   let(:config)        { 'spec/fixtures/config.yml' }
   let(:logstash_home) { '.' }
-  let(:suite_def)     { 'spec/fixtures/basic_suite.rb' }
+  let(:suite_def)     { 'spec/fixtures/worker_basic_suite.rb' }
   let(:serial_runner) { double('DummySerialRunner') }
   let(:runner)        { LogStash::PerformanceMeter::Runner }
 
   let(:run_outcome)   { { :percentile => [2000] , :elapsed => 100, :events_count => 3000, :start_time => 12 } }
   subject(:manager) { LogStash::PerformanceMeter::Core.new(suite_def, logstash_home, config, runner) }
 
-  context "with a valid configuration" do
+  context "with a valid configuration and worker threads set to 2" do
     before(:each) do
       expect(serial_runner).to receive(:run).with(0, 5, anything()).ordered  { run_outcome }
       expect(serial_runner).to receive(:run).with(0, 10, anything()).ordered { run_outcome }
@@ -19,7 +19,7 @@ describe LogStash::PerformanceMeter::Core do
     context "using a file" do
 
       it "run each test case in a serial maner" do
-        expect(runner).to receive(:new).with("spec/fixtures/simple.conf", "1", false, logstash_home).twice { serial_runner }
+        expect(runner).to receive(:new).with("spec/fixtures/simple.conf", "2", false, logstash_home).twice { serial_runner }
         manager.run
       end
 
@@ -31,21 +31,10 @@ describe LogStash::PerformanceMeter::Core do
 
       it "run each test case as expected" do
         expect(runner).to receive(:read_input_file).with('simple_10.txt').twice { [] }
-        expect(runner).to receive(:new).with("simple.conf", "1", false, logstash_home).twice { serial_runner }
+        expect(runner).to receive(:new).with("simple.conf", "2", false, logstash_home).twice { serial_runner }
         manager.run
       end
 
     end
   end
-
-  context "with a wrong configuration" do
-
-    let(:config)        { 'spec/fixtures/wrong_config.yml' }
-
-    it "run each test case as expected" do
-      expect(runner).to receive(:new).with("spec/wrong_fixture/simple.conf", "1", false, logstash_home).once { serial_runner }
-      expect { manager.run }.to raise_error(LogStash::PerformanceMeter::ConfigException)
-    end
-  end
-
 end


### PR DESCRIPTION
This change fixes issue #23 

It adds the ability to (optionally) specify the amount of worker threads for each test in a suite, by adding `:workers => N` to the test. If it's not there, it defaults to 1 worker, which is what logstash does by default itself if you don't specify `-w` to it.