### PR TITLE
fix environment initialization

### DIFF
--- a/examples/suite/basic_performance_long.rb
+++ b/examples/suite/basic_performance_long.rb
@@ -7,12 +7,19 @@
 #  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
 #]
 #
+TIME = 120
+CONFIG_PATH = "examples/config/"
+INPUT_PATH = "examples/input/"
+
 [
-  {:name => "simple line in/out", :config => "config/simple.conf", :input => "input/simple_10.txt", :time => 120},
-  {:name => "simple line in/json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 120},
-  {:name => "json codec in/out", :config => "config/json_inout_codec.conf", :input => "input/json_medium.txt", :time => 120},
-  {:name => "line in/json filter/json out", :config => "config/json_inout_filter.conf", :input => "input/json_medium.txt", :time => 120},
-  {:name => "apache in/json out", :config => "config/simple.conf", :input => "input/apache_log.txt", :time => 120},
-  {:name => "apache in/grok codec/json out", :config => "config/simple_grok.conf", :input => "input/apache_log.txt", :time => 120},
-  {:name => "syslog in/json out", :config => "config/complex_syslog.conf", :input => "input/syslog_acl_10.txt", :time => 120},
-]
+  {:name => "simple line in/out", :config => "simple.conf", :input => "simple_10.txt", :time => TIME},
+  {:name => "simple line in/json out", :config => "simple_json_out.conf", :input => "simple_10.txt", :time => TIME},
+  {:name => "json codec in/out", :config => "json_inout_codec.conf", :input => "json_medium.txt", :time => TIME},
+  {:name => "line in/json filter/json out", :config => "json_inout_filter.conf", :input => "json_medium.txt", :time => TIME},
+  {:name => "apache in/json out", :config => "simple.conf", :input => "apache_log.txt", :time => TIME},
+  {:name => "apache in/grok codec/json out", :config => "simple_grok.conf", :input => "apache_log.txt", :time => TIME},
+  {:name => "syslog in/json out", :config => "complex_syslog.conf", :input => "syslog_acl_10.txt", :time => TIME},
+].map do |test|
+  test.merge({:config => CONFIG_PATH + test[:config], :input => INPUT_PATH + test[:input], :time => TIME})
+end
+

--- a/examples/suite/basic_performance_quick.rb
+++ b/examples/suite/basic_performance_quick.rb
@@ -7,12 +7,18 @@
 #  {:name => "simple json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :events => 50000},
 #]
 #
+TIME = 30
+CONFIG_PATH = "examples/config/"
+INPUT_PATH = "examples/input/"
+
 [
-  {:name => "simple line in/out", :config => "config/simple.conf", :input => "input/simple_10.txt", :time => 30},
-  {:name => "simple line in/json out", :config => "config/simple_json_out.conf", :input => "input/simple_10.txt", :time => 30},
-  {:name => "json codec in/out", :config => "config/json_inout_codec.conf", :input => "input/json_medium.txt", :time => 30},
-  {:name => "line in/json filter/json out", :config => "config/json_inout_filter.conf", :input => "input/json_medium.txt", :time => 30},
-  {:name => "apache in/json out", :config => "config/simple.conf", :input => "input/apache_log.txt", :time => 30},
-  {:name => "apache in/grok codec/json out", :config => "config/simple_grok.conf", :input => "input/apache_log.txt", :time => 30},
-  {:name => "syslog in/json out", :config => "config/complex_syslog.conf", :input => "input/syslog_acl_10.txt", :time => 30},
-]
+  {:name => "simple line in/out", :config => "simple.conf", :input => "simple_10.txt", :time => TIME},
+  {:name => "simple line in/json out", :config => "simple_json_out.conf", :input => "simple_10.txt", :time => TIME},
+  {:name => "json codec in/out", :config => "json_inout_codec.conf", :input => "json_medium.txt", :time => TIME},
+  {:name => "line in/json filter/json out", :config => "json_inout_filter.conf", :input => "json_medium.txt", :time => TIME},
+  {:name => "apache in/json out", :config =>  "simple.conf", :input => "apache_log.txt", :time => TIME},
+  {:name => "apache in/grok codec/json out", :config => "simple_grok.conf", :input => "apache_log.txt", :time => TIME},
+  {:name => "syslog in/json out", :config => "complex_syslog.conf", :input => "syslog_acl_10.txt", :time => TIME},
+].map do |test|
+  test.merge({:config => CONFIG_PATH + test[:config], :input => INPUT_PATH + test[:input], :time => TIME})
+end

--- a/lib/lsperfm/core/run.rb
+++ b/lib/lsperfm/core/run.rb
@@ -27,7 +27,7 @@ module LogStash::PerformanceMeter
       puts("launching #{command.join(" ")} #{required_events_count} #{required_run_time}") if @debug
       stats = LogStash::PerformanceMeter::Stats.new
       real_events_count = 0
-      Open3.popen3(*@command) do |i, o, e|
+      Open3.popen3({:BUNDLE_BIN_PATH => "", :BUNDLE_GEMFILE => "", :RUBYOPT => ""}, *@command) do |i, o, e|
         puts("sending initial event") if @debug
         start_time = Benchmark.realtime do
           i.puts(INITIAL_MESSAGE)


### PR DESCRIPTION
two fixes:

1- an env hash is passed to popen3 to make sure to reset any bundler settings to not interfere with the launched app. this allow launching an external logstash from the performance testing dir, for example:

``` sh
bundle exec bin/lsperfm examples/suite/basic_performance_quick.rb  /Users/colin/dev/src/elasticsearch/logstash
```

2- correctly sets path for suites configs.
